### PR TITLE
Refactor respondent id methods

### DIFF
--- a/src/main/java/com/github/onsdigital/perkin/json/Metadata.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Metadata.java
@@ -16,7 +16,7 @@ public class Metadata {
     /**
      * @return empty String if null, the first 11 characters if the length is 12 and the last character is a letter, otherwise the full String
      */
-    public String getRespondentId() {
+    public String getRuRefId() {
         if (ruRef == null) {
             return "";
         }
@@ -33,7 +33,7 @@ public class Metadata {
         return ruRef;
     }
 
-    public char getRespondentCheckLetter() {
+    public char getRuRefCheckLetter() {
         int length = ruRef.length();
 
         if (ruRef == null || length < 12) {

--- a/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
@@ -203,7 +203,7 @@ public class TransformEngine {
 
         receiptData = receiptData.replace("{respondent_id}", respondentId);
 
-        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.collections+xml");
+        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.ons.receipt+xml");
 
         Response<String> receiptResponse = new Http().postString(receiptEndpoint, receiptData, applicationType);
 

--- a/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
@@ -203,7 +203,7 @@ public class TransformEngine {
 
         receiptData = receiptData.replace("{respondent_id}", respondentId);
 
-        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.ons.receipt+xml");
+        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.collections+xml");
 
         Response<String> receiptResponse = new Http().postString(receiptEndpoint, receiptData, applicationType);
 

--- a/src/main/java/com/github/onsdigital/perkin/transform/idbr/IdbrTransformer.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/idbr/IdbrTransformer.java
@@ -66,9 +66,9 @@ public class IdbrTransformer implements Transformer {
     private String createReceipt(final Survey survey) {
 
         final StringBuilder receipt = new StringBuilder()
-            .append(survey.getMetadata().getRespondentId())
+            .append(survey.getMetadata().getRuRefId())
             .append(DELIMITER)
-            .append(survey.getMetadata().getRespondentCheckLetter())
+            .append(survey.getMetadata().getRuRefCheckLetter())
             .append(DELIMITER)
             .append(TransformerHelper.leftPadZeroes(survey.getId(), 3))
             .append(DELIMITER)

--- a/src/main/java/com/github/onsdigital/perkin/transform/jpg/ImageIndexCsvCreator.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/jpg/ImageIndexCsvCreator.java
@@ -41,7 +41,7 @@ public class ImageIndexCsvCreator {
                 .append(scanId).append(COMMA)
                 .append(survey.getId()).append(COMMA)
                 .append(survey.getCollection().getInstrumentId()).append(COMMA)
-                .append(survey.getMetadata().getRespondentId()).append(COMMA)
+                .append(survey.getMetadata().getRuRefId()).append(COMMA)
                 .append(survey.getCollection().getPeriod()).append(COMMA)
                 .append(format(pageNumber));
 


### PR DESCRIPTION
Rename the current respondent id methods to avoid confusion with downstream systems use of respondent id (where the term means a responding user_id). getRuRefId could be refactored further to getStatisticalUnitId, but is probably unnecessary for us.

This tallies with Rachels investigation of term differences between each of the components.