### PR TITLE
Correct call to RRM and refactor method

### DIFF
--- a/src/main/java/com/github/onsdigital/perkin/json/Metadata.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Metadata.java
@@ -16,7 +16,7 @@ public class Metadata {
     /**
      * @return empty String if null, the first 11 characters if the length is 12 and the last character is a letter, otherwise the full String
      */
-    public String getRuRefId() {
+    public String getStatisticalUnitId() {
         if (ruRef == null) {
             return "";
         }

--- a/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
@@ -193,7 +193,7 @@ public class TransformEngine {
             return true;
         }
 
-        String receiptURI = receiptPath + "/" + survey.getMetadata().getRuRef() + "/collectionexercises/"
+        String receiptURI = receiptPath + "/" + survey.getMetadata().getStatisticalUnitId() + "/collectionexercises/"
                 + survey.getCollection().getExerciseSid() + "/receipts";
 
         Endpoint receiptEndpoint = new Endpoint(new Host(receiptHost), receiptURI);

--- a/src/main/java/com/github/onsdigital/perkin/transform/idbr/IdbrTransformer.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/idbr/IdbrTransformer.java
@@ -66,7 +66,7 @@ public class IdbrTransformer implements Transformer {
     private String createReceipt(final Survey survey) {
 
         final StringBuilder receipt = new StringBuilder()
-            .append(survey.getMetadata().getRuRefId())
+            .append(survey.getMetadata().getStatisticalUnitId())
             .append(DELIMITER)
             .append(survey.getMetadata().getRuRefCheckLetter())
             .append(DELIMITER)

--- a/src/main/java/com/github/onsdigital/perkin/transform/jpg/ImageIndexCsvCreator.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/jpg/ImageIndexCsvCreator.java
@@ -41,7 +41,7 @@ public class ImageIndexCsvCreator {
                 .append(scanId).append(COMMA)
                 .append(survey.getId()).append(COMMA)
                 .append(survey.getCollection().getInstrumentId()).append(COMMA)
-                .append(survey.getMetadata().getRuRefId()).append(COMMA)
+                .append(survey.getMetadata().getStatisticalUnitId()).append(COMMA)
                 .append(survey.getCollection().getPeriod()).append(COMMA)
                 .append(format(pageNumber));
 


### PR DESCRIPTION
Use the "StatisticalUnitId" as a metadata method to retrieve ru ref without checkletter appended, rather than ru ref id, which will mostly likely confuse things further down the line.

Additionally, correct the call to rrm to use this method, rather than the full ru ref.