### PR TITLE
Refactor to better enable testing

### DIFF
--- a/src/main/java/com/github/onsdigital/ConfigurationManager.java
+++ b/src/main/java/com/github/onsdigital/ConfigurationManager.java
@@ -64,6 +64,16 @@ public class ConfigurationManager {
         return getInstance().getValue(key);
     }
 
+    /**
+     * Allow setting within configuration manager to facilitate tests
+     *
+     * @param key
+     * @param value
+     */
+    public static void set(String key, String value) {
+        getInstance().add(key, value);
+    }
+
     public static int getInt(String key) {
         int i = -1;
         String value = get(key);

--- a/src/main/java/com/github/onsdigital/perkin/helper/TemplateLoader.java
+++ b/src/main/java/com/github/onsdigital/perkin/helper/TemplateLoader.java
@@ -1,0 +1,83 @@
+package com.github.onsdigital.perkin.helper;
+
+import com.github.davidcarboni.httpino.Serialiser;
+import com.github.onsdigital.perkin.json.Survey;
+import com.github.onsdigital.perkin.json.SurveyTemplate;
+import com.github.onsdigital.perkin.transform.Audit;
+import com.github.onsdigital.perkin.transform.TemplateNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.io.IOException;
+
+/**
+ * A class for loading and maintaining a set of cached templates from disk
+ *
+ * Created by ian on 30/03/2016.
+ */
+@Slf4j
+public class TemplateLoader {
+
+    private static final TemplateLoader INSTANCE = new TemplateLoader();
+
+    private Map<String, String> templates;
+
+    private Audit audit = Audit.getInstance();
+
+    private TemplateLoader() {
+        templates = new HashMap<>();
+    }
+
+    public static TemplateLoader getInstance() {
+        return INSTANCE;
+    }
+
+    public String getPdfTemplate(Survey survey) throws TemplateNotFoundException {
+        return this.getTemplate("templates/" + survey.getId() + "."
+                + survey.getCollection().getInstrumentId() + ".pdf.fo");
+    }
+
+    public SurveyTemplate getSurveyTemplate(Survey survey) throws TemplateNotFoundException {
+
+        String json = this.getTemplate("templates/" + survey.getId() + "."
+                + survey.getCollection().getInstrumentId() + ".survey.json");
+
+        return Serialiser.deserialise(json, SurveyTemplate.class);
+    }
+
+    public String getTemplate(String templateFilename) throws TemplateNotFoundException {
+
+        //only time if we load the template
+        Timer timer = null;
+
+        String template = null;
+
+        try {
+            //only load a template once
+            template = templates.get(templateFilename);
+
+            if (template == null) {
+
+                timer = new Timer("template.load.");
+                timer.addInfo(templateFilename);
+
+                template = FileHelper.loadFile(templateFilename);
+                templates.put(templateFilename, template);
+
+                timer.stopStatus(200);
+
+                log.debug("TEMPLATE|storing template: " + templateFilename);
+            }
+        } catch (IOException e) {
+            if (timer != null) {
+                timer.stopStatus(500, e);
+            }
+            throw new TemplateNotFoundException("problem loading template: " + templateFilename);
+        } finally {
+            audit.increment(timer);
+        }
+
+        return template;
+    }
+}

--- a/src/main/java/com/github/onsdigital/perkin/json/Survey.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Survey.java
@@ -1,20 +1,34 @@
 package com.github.onsdigital.perkin.json;
 
+import com.github.davidcarboni.httpino.Endpoint;
+import com.github.davidcarboni.httpino.Host;
+import com.github.onsdigital.ConfigurationManager;
+import com.github.onsdigital.perkin.helper.Http;
+import com.github.onsdigital.perkin.helper.TemplateLoader;
+import com.github.onsdigital.perkin.helper.Timer;
+import com.github.onsdigital.perkin.transform.Audit;
+import com.github.onsdigital.perkin.transform.TransformException;
+import com.github.davidcarboni.httpino.Response;
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Singular;
-
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.message.BasicNameValuePair;
+import org.eclipse.jetty.http.HttpStatus;
+import java.io.IOException;
 
 /**
  * Simple object to contain Survey data.
  */
 @Data
 @Builder
+@Slf4j
 public class Survey {
 
     private String type;
@@ -48,5 +62,48 @@ public class Survey {
         }
 
         return answers.keySet();
+    }
+
+    public Boolean sendReceipt() throws IOException {
+        Timer timer = new Timer("receipt.");
+        Audit audit = Audit.getInstance();
+        TemplateLoader loader = TemplateLoader.getInstance();
+
+        String receiptHost = ConfigurationManager.get("receipt.host");
+        String receiptPath = ConfigurationManager.get("receipt.path");
+
+        if (receiptHost.equals("skip")) {
+            Audit.getInstance().increment("receipt.host.skipped");
+            log.warn("RECEIPT|SKIP|skipping sending receipt to RM");
+            return true;
+        }
+
+        String receiptURI = receiptPath + "/" + this.getMetadata().getRuRef() + "/collectionexercises/"
+                + this.getCollection().getExerciseSid() + "/receipts";
+
+        Endpoint receiptEndpoint = new Endpoint(new Host(receiptHost), receiptURI);
+
+        String receiptData = loader.getTemplate("templates/receipt.xml");
+        String respondentId = this.getMetadata().getUserId();
+
+        receiptData = receiptData.replace("{respondent_id}", respondentId);
+
+        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.ons.receipt+xml");
+
+        Response<String> receiptResponse = new Http().postString(receiptEndpoint, receiptData, applicationType);
+
+        int status = receiptResponse.statusLine.getStatusCode();
+
+        timer.stopStatus(status);
+
+        audit.increment(timer);
+
+        if (status == HttpStatus.BAD_REQUEST_400) {
+            log.error("RECEIPT|RESPONSE|Failed for respondent: {}", respondentId);
+        } else if (status != HttpStatus.CREATED_201) {
+            throw new TransformException("receipt response indicated an error: " + receiptResponse);
+        }
+
+        return status == HttpStatus.CREATED_201;
     }
 }

--- a/src/main/java/com/github/onsdigital/perkin/json/Survey.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Survey.java
@@ -95,15 +95,17 @@ public class Survey {
 
     public String getReceiptContent() throws TemplateNotFoundException {
         TemplateLoader loader = TemplateLoader.getInstance();
+        String respondentId = this.getMetadata().getUserId();
+        String template = loader.getTemplate("templates/receipt.xml");
 
-        return loader.getTemplate("templates/receipt.xml");
+        return template.replace("{respondent_id}", respondentId);
     }
 
     public Boolean sendReceipt() throws IOException {
         Timer timer = new Timer("receipt.");
         Audit audit = Audit.getInstance();
 
-        String receiptHost = ConfigurationManager.get("receipt.host");
+        String receiptHost = ConfigurationManager.get("RECEIPT_HOST");
 
         if (receiptHost.equals("skip")) {
             Audit.getInstance().increment("receipt.host.skipped");

--- a/src/main/java/com/github/onsdigital/perkin/json/SurveyTemplate.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/SurveyTemplate.java
@@ -17,4 +17,5 @@ public class SurveyTemplate {
     private String formType;
     @Singular("question")
 	private List<QuestionTemplate> questions;
+
 }

--- a/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
+++ b/src/main/java/com/github/onsdigital/perkin/transform/TransformEngine.java
@@ -1,14 +1,8 @@
 package com.github.onsdigital.perkin.transform;
 
-import com.github.davidcarboni.httpino.Endpoint;
-import com.github.davidcarboni.httpino.Host;
-import com.github.davidcarboni.httpino.Response;
-import com.github.davidcarboni.httpino.Serialiser;
-import com.github.onsdigital.ConfigurationManager;
 import com.github.onsdigital.Json;
 import com.github.onsdigital.perkin.decrypt.HttpDecrypt;
-import com.github.onsdigital.perkin.helper.FileHelper;
-import com.github.onsdigital.perkin.helper.Http;
+import com.github.onsdigital.perkin.helper.TemplateLoader;
 import com.github.onsdigital.perkin.helper.Timer;
 import com.github.onsdigital.perkin.json.*;
 import com.github.onsdigital.perkin.transform.idbr.IdbrTransformer;
@@ -17,8 +11,9 @@ import com.github.onsdigital.perkin.transform.pck.PckTransformer;
 import com.github.onsdigital.perkin.publish.FtpPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.StatusLine;
-import org.apache.http.message.BasicNameValuePair;
 import org.eclipse.jetty.http.HttpStatus;
+
+import com.github.davidcarboni.httpino.Response;
 
 import java.io.IOException;
 import java.util.*;
@@ -34,12 +29,13 @@ public class TransformEngine {
     private SurveyParser parser = new SurveyParser();
     private HttpDecrypt decrypt = new HttpDecrypt();
 
-    private Map<String, String> templates;
+    private Audit audit = Audit.getInstance();
+    private TemplateLoader loader = TemplateLoader.getInstance();
+
     private List<Transformer> transformers;
 
     private FtpPublisher publisher = new FtpPublisher();
 
-    private Audit audit = Audit.getInstance();
     private NumberService batchNumberService = new NumberService("batch", 30000, 39999);
     private NumberService sequenceNumberService = new NumberService("sequence", 1000, 99999);
     private NumberService scanNumberService = new NumberService("scan", 1, 999999999);
@@ -49,7 +45,6 @@ public class TransformEngine {
         //TODO: make configurable
         //TODO: also, transformers on a per survey id basis?
         transformers = Arrays.asList(new IdbrTransformer(), new PckTransformer(), new ImageTransformer());
-        templates = new HashMap<>();
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {
@@ -91,7 +86,7 @@ public class TransformEngine {
 
             publisher.publish(files);
 
-            sendReceipt(survey);
+            survey.sendReceipt();
 
             timer.stopStatus(200);
 
@@ -116,52 +111,9 @@ public class TransformEngine {
                 .batch(batchNumberService.getNext())
                 .sequence(sequenceNumberService.getNext())
                 .scanNumberService(scanNumberService)
-                .surveyTemplate(getSurveyTemplate(survey))
-                .pdfTemplate(getPdfTemplate(survey))
+                .surveyTemplate(loader.getSurveyTemplate(survey))
+                .pdfTemplate(loader.getPdfTemplate(survey))
                 .build();
-    }
-
-    private String getPdfTemplate(Survey survey) throws TemplateNotFoundException {
-        return getTemplate("templates/" + survey.getId() + "." + survey.getCollection().getInstrumentId() + ".pdf.fo");
-    }
-
-    private SurveyTemplate getSurveyTemplate(Survey survey) throws TemplateNotFoundException {
-
-        String json = getTemplate("templates/" + survey.getId() + "." + survey.getCollection().getInstrumentId() + ".survey.json");
-        return Serialiser.deserialise(json, SurveyTemplate.class);
-    }
-
-    private String getTemplate(String templateFilename) throws TemplateNotFoundException {
-
-        //only time if we load the template
-        Timer timer = null;
-
-        String pdfTemplate = null;
-
-        try {
-            //only load a template once
-            pdfTemplate = templates.get(templateFilename);
-            if (pdfTemplate == null) {
-
-                timer = new Timer("template.pdf.load.");
-                timer.addInfo(templateFilename);
-
-                pdfTemplate = FileHelper.loadFile(templateFilename);
-                templates.put(templateFilename, pdfTemplate);
-
-                timer.stopStatus(200);
-                log.debug("TEMPLATE|storing template: " + templateFilename);
-            }
-        } catch (IOException e) {
-            if (timer != null) {
-                timer.stopStatus(500, e);
-            }
-            throw new TemplateNotFoundException("problem loading pdf template: " + templateFilename);
-        } finally {
-            audit.increment(timer);
-        }
-
-        return pdfTemplate;
     }
 
     private String decrypt(String data) throws IOException {
@@ -179,47 +131,6 @@ public class TransformEngine {
         }
 
         return decryptResponse.body;
-    }
-
-    private Boolean sendReceipt(Survey survey) throws IOException {
-        Timer timer = new Timer("receipt.");
-
-        String receiptHost = ConfigurationManager.get("receipt.host");
-        String receiptPath = ConfigurationManager.get("receipt.path");
-
-        if (receiptHost.equals("skip")) {
-            Audit.getInstance().increment("receipt.host.skipped");
-            log.warn("RECEIPT|SKIP|skipping sending receipt to RM");
-            return true;
-        }
-
-        String receiptURI = receiptPath + "/" + survey.getMetadata().getRuRef() + "/collectionexercises/"
-                + survey.getCollection().getExerciseSid() + "/receipts";
-
-        Endpoint receiptEndpoint = new Endpoint(new Host(receiptHost), receiptURI);
-
-        String receiptData = getTemplate("templates/receipt.xml");
-        String respondentId = survey.getMetadata().getUserId();
-
-        receiptData = receiptData.replace("{respondent_id}", respondentId);
-
-        BasicNameValuePair applicationType = new BasicNameValuePair("Content-Type", "application/vnd.ons.receipt+xml");
-
-        Response<String> receiptResponse = new Http().postString(receiptEndpoint, receiptData, applicationType);
-
-        int status = receiptResponse.statusLine.getStatusCode();
-
-        timer.stopStatus(status);
-
-        audit.increment(timer);
-
-        if (status == HttpStatus.BAD_REQUEST_400) {
-            log.error("RECEIPT|RESPONSE|Failed for respondent: {}", respondentId);
-        } else if (status != HttpStatus.CREATED_201) {
-            throw new TransformException("receipt response indicated an error: " + receiptResponse);
-        }
-
-        return status == HttpStatus.CREATED_201;
     }
 
     private boolean isError(StatusLine statusLine) {

--- a/src/test/java/com/github/onsdigital/perkin/helper/TemplateLoaderTest.java
+++ b/src/test/java/com/github/onsdigital/perkin/helper/TemplateLoaderTest.java
@@ -1,0 +1,44 @@
+package com.github.onsdigital.perkin.helper;
+
+import com.github.onsdigital.perkin.json.Survey;
+import com.github.onsdigital.perkin.json.SurveyParser;
+import com.github.onsdigital.perkin.json.SurveyTemplate;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by ian on 01/04/2016.
+ */
+public class TemplateLoaderTest {
+
+    private TemplateLoader loader;
+    
+    private static String TEST_TEMPLATE_JSON = "templates/023.0203.survey.json";
+    private static String TEST_TEMPLATE_PDF = "templates/023.0203.pdf.fo";
+    private static String TEST_SURVEY_JSON = "survey.ftp.json";
+
+    @Before
+    public void setUp() {
+        loader = TemplateLoader.getInstance();
+    }
+
+    @Test
+    public void shouldLoadTemplate() throws IOException {
+        String surveyContent = FileHelper.loadFile(TEST_TEMPLATE_JSON);
+
+        assertThat(surveyContent, is(loader.getTemplate(TEST_TEMPLATE_JSON)));
+    }
+
+    @Test
+    public void shouldLoadPdfTemplate() throws IOException {
+        String pdfTemplateContent = FileHelper.loadFile(TEST_TEMPLATE_PDF);
+        Survey testSurvey = new SurveyParser().parse(FileHelper.loadFile(TEST_SURVEY_JSON));
+
+        assertThat(pdfTemplateContent, is(loader.getPdfTemplate(testSurvey)));
+    }
+}

--- a/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
+++ b/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
@@ -1,0 +1,81 @@
+package com.github.onsdigital.perkin.json;
+
+import com.github.davidcarboni.httpino.Endpoint;
+import com.github.davidcarboni.httpino.Host;
+import com.github.onsdigital.ConfigurationManager;
+import com.github.onsdigital.perkin.helper.FileHelper;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by ian on 01/04/2016.
+ */
+public class SurveyTest {
+
+    Survey testSurvey;
+
+    @Before
+    public void setUp() throws IOException {
+        ConfigurationManager.set("receipt.host", "http://localhost:5000");
+        ConfigurationManager.set("receipt.path", "reportingunits");
+
+        testSurvey = new SurveyParser().parse(FileHelper.loadFile("survey.ftp.json"));
+    }
+
+    /**
+     * Retrieve a receipt header
+     * @param key The key to return
+     * @return The value for the key
+     */
+    public String getHeaderValue(String key) {
+        BasicNameValuePair[] headers = testSurvey.getReceiptHeaders();
+
+        for(BasicNameValuePair header: headers) {
+            if(header.getName() == key) {
+                return header.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void shouldUseCorrectEndpoint() {
+        String receiptHost = ConfigurationManager.get("receipt.host");
+        String receiptPath = ConfigurationManager.get("receipt.path");
+
+        String receiptURI = receiptPath + "/" + testSurvey.getMetadata().getRuRef() + "/collectionexercises/"
+                + testSurvey.getCollection().getExerciseSid() + "/receipts";
+
+        Endpoint receiptEndpoint = new Endpoint(new Host(receiptHost), receiptURI);
+
+        assertThat(testSurvey.getReceiptEndpoint().toString(), is(receiptEndpoint.toString()));
+    }
+
+    @Test
+    public void shouldSetContentTypeHeader() {
+        String contentType = getHeaderValue("Content-Type");
+
+        assertThat(contentType, is("application/vnd.ons.receipt+xml"));
+    }
+
+    @Test
+    public void hasWellFormedReceiptContent() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        // Parse will throw an exception if not well formed
+        builder.parse(new InputSource(new StringReader(testSurvey.getReceiptContent())));
+    }
+}

--- a/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
+++ b/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
@@ -4,7 +4,9 @@ import com.github.davidcarboni.httpino.Endpoint;
 import com.github.davidcarboni.httpino.Host;
 import com.github.onsdigital.ConfigurationManager;
 import com.github.onsdigital.perkin.helper.FileHelper;
+import com.github.onsdigital.perkin.transform.TemplateNotFoundException;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.xalan.xsltc.compiler.Template;
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.InputSource;
@@ -25,13 +27,13 @@ import static org.mockito.Mockito.*;
  */
 public class SurveyTest {
 
-    Survey testSurvey;
+    private Survey testSurvey;
 
-    static final String RECEIPT_HOST = "http://localhost:5000";
-    static final String RECEIPT_PATH = "reportingunits";
+    private static final String RECEIPT_HOST = "http://localhost:5000";
+    private static final String RECEIPT_PATH = "reportingunits";
 
-    static final String RECEIPT_USER = "test";
-    static final String RECEIPT_PASS = "test";
+    private static final String RECEIPT_USER = "test";
+    private static final String RECEIPT_PASS = "test";
 
     @Before
     public void setUp() throws IOException {
@@ -86,8 +88,12 @@ public class SurveyTest {
     }
 
     @Test
-    public void shouldHaveCorrectContent() {
+    public void shouldHaveCorrectRespondentId() throws TemplateNotFoundException {
+        String content = testSurvey.getReceiptContent();
 
+        String respondentId = content.split("<respondent_id>")[1].split("</respondent_id>")[0];
+
+        assertThat(respondentId, is(testSurvey.getMetadata().getUserId()));
     }
 
     @Test

--- a/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
+++ b/src/test/java/com/github/onsdigital/perkin/json/SurveyTest.java
@@ -88,7 +88,7 @@ public class SurveyTest {
     }
 
     @Test
-    public void shouldHaveCorrectRespondentId() throws TemplateNotFoundException {
+    public void shouldContainRespondentId() throws TemplateNotFoundException {
         String content = testSurvey.getReceiptContent();
 
         String respondentId = content.split("<respondent_id>")[1].split("</respondent_id>")[0];


### PR DESCRIPTION
In order to write some meaningful tests for sending a RRM receipt, I've refactored some of my previous work and current methods for template loading.

Points of note:

- I've moved the sendReceipt call to rrm into the survey class itself. This enables me to test the attributes of the receipt without having to load/mock up all the dependencies within the transform engine that it was previously a part of.

- I've refactored template loading into a globally available TemplateLoader which can be pulled in from anywhere, removing the behaviour from TransformEngine. I've added the start of some tests for this. 

- I've added a configuration manager "setter" method in order to be able to set environment variables within our tests, rather than only being to load them from the environment. 

Creating the tests for the features of the receipt have better enabled me to see where elements of the receipt could be broken up further to enable better tests. I dare say we could do similar for the call out to Posie.