### PR TITLE
Log receipt failures rather than requeue

### DIFF
--- a/src/main/java/com/github/onsdigital/perkin/helper/FileHelper.java
+++ b/src/main/java/com/github/onsdigital/perkin/helper/FileHelper.java
@@ -44,6 +44,17 @@ public abstract class FileHelper {
         log.info("saved file target/example/" + filename);
     }
 
+    public static List<String> loadFileAsList(String filename) throws IOException {
+
+        Path path = Paths.get("target/" + filename);
+
+        List<String> lines = Files.readAllLines(path);
+
+        log.info("loaded file target/" + filename + " contents: {}", lines);
+
+        return lines;
+    }
+
     public static byte[] loadFileAsBytes(String filename) throws IOException {
 
         log.debug("loading file: " + filename);

--- a/src/main/java/com/github/onsdigital/perkin/json/Survey.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Survey.java
@@ -125,10 +125,8 @@ public class Survey {
 
         audit.increment(timer);
 
-        if (status == HttpStatus.BAD_REQUEST_400) {
-            log.error("RECEIPT|RESPONSE|Failed for respondent: {}", this.getMetadata().getUserId());
-        } else if (status != HttpStatus.CREATED_201) {
-            throw new TransformException("receipt response indicated an error: " + receiptResponse);
+        if (status != HttpStatus.CREATED_201) {
+            log.error("RECEIPT|RESPONSE|ERROR: Receipt failed for respondent_id={}", this.getMetadata().getUserId());
         }
 
         return status == HttpStatus.CREATED_201;

--- a/src/test/java/com/github/onsdigital/perkin/services/ReceiptTest.java
+++ b/src/test/java/com/github/onsdigital/perkin/services/ReceiptTest.java
@@ -26,6 +26,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Base64;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -134,8 +135,8 @@ public class ReceiptTest {
                 eq(testSurvey.getReceiptContent()), argThat(new MatchesHeaders(testSurvey.getReceiptHeaders())));
     }
 
-    @Test(expected=TransformException.class)
-    public void shouldThrowTransformExceptionOnReceiptError() throws Exception {
+    @Test
+    public void shouldLogReceiptError() throws Exception {
 
         Response mockResponse = new MockedResponse(mock(StatusLine.class), "Some Mock Response");
 
@@ -145,6 +146,13 @@ public class ReceiptTest {
 
         testSurvey.sendReceipt();
 
+        List<String> testLogContents = FileHelper.loadFileAsList("test.log");
+        String lastLine = testLogContents.get(testLogContents.size() - 1);
+
+        String expectedLogMessage = "RECEIPT|RESPONSE|ERROR: Receipt failed for respondent_id="
+                + testSurvey.getMetadata().getUserId();
+
+        assert lastLine.contains(expectedLogMessage);
     }
 
     /**


### PR DESCRIPTION
Don't re-queue receipt failures, rather log the error for splunk to pick up and handle.