### PR TITLE
Don't log body of HTTP responses

### DIFF
--- a/src/main/java/com/github/onsdigital/perkin/decrypt/Decrypt.java
+++ b/src/main/java/com/github/onsdigital/perkin/decrypt/Decrypt.java
@@ -56,10 +56,10 @@ public class Decrypt {
         timer.stopStatus(decryptResponse.statusLine.getStatusCode());
         audit.increment(timer);
 
-        log.debug("DECRYPT|RESPONSE|survey: {}", decryptResponse);
+        log.debug("DECRYPT|RESPONSE|survey: {}", decryptResponse.statusLine);
 
         if (isError(decryptResponse.statusLine)) {
-            log.warn("DECRYPT|RESPONSE|FAIL|failed to decrypt data: {} response: {}", encryptedData, decryptResponse);
+            log.warn("DECRYPT|RESPONSE|FAIL|failed to decrypt data: {} response: {}", encryptedData, decryptResponse.statusLine);
             throw new TransformException("decrypt response indicated an error: " + decryptResponse);
         }
 

--- a/src/main/java/com/github/onsdigital/perkin/helper/Http.java
+++ b/src/main/java/com/github/onsdigital/perkin/helper/Http.java
@@ -162,7 +162,6 @@ public class Http implements AutoCloseable {
         // Send the request and process the response
         try (CloseableHttpResponse response = httpClient().execute(post)) {
             String body = deserialiseResponseMessage(response);
-            log.debug("HTTP|response body: {}", body);
             return new Response<>(response.getStatusLine(), body);
         }
     }
@@ -183,7 +182,6 @@ public class Http implements AutoCloseable {
         // Send the request and process the response
         try (CloseableHttpResponse response = httpClient().execute(post)) {
             String body = deserialiseResponseMessage(response);
-            log.debug("HTTP|response body: {}", body);
             return new Response<>(response.getStatusLine(), body);
         }
     }
@@ -562,8 +560,6 @@ public class Http implements AutoCloseable {
         } else {
             EntityUtils.consume(entity);
         }
-
-        log.debug("HTTP|body: {}", body);
 
         return body;
     }

--- a/src/main/java/com/github/onsdigital/perkin/json/Survey.java
+++ b/src/main/java/com/github/onsdigital/perkin/json/Survey.java
@@ -127,6 +127,8 @@ public class Survey {
 
         if (status != HttpStatus.CREATED_201) {
             log.error("RECEIPT|RESPONSE|ERROR: Receipt failed for respondent_id={}", this.getMetadata().getUserId());
+        } else {
+            log.info("RECEIPT|RESPONSE|SUCCESS: Receipt success for respondent_id={}", this.getMetadata().getUserId());
         }
 
         return status == HttpStatus.CREATED_201;


### PR DESCRIPTION
**Changes**

- Remove decrypted survey logging / HTTP response body logging (Both expose raw decrypted json)
- Explicitly log successful calls to RRM

**How to test**

- Run on aws environment and check whether payloads appear in logs
- Run on preprod and ensure successful receipts are logged

**Who can test**

Anyone but @iwootten