### PR TITLE
close connection, not channel

### DIFF
--- a/src/main/java/com/github/onsdigital/perkin/SurveyListener.java
+++ b/src/main/java/com/github/onsdigital/perkin/SurveyListener.java
@@ -132,7 +132,7 @@ public class SurveyListener implements Runnable, RecoveryListener {
         channel.queueDeclare(queue, false, false, false, null);
 
         String version = channel.getConnection().getServerProperties().get("version").toString();
-        channel.close();
+        connection.close();
 
         return version;
     }


### PR DESCRIPTION
splunk caused the queue to fail by testing the queue connection every 60 secs. this should fix it, we were closing the channel and not the connection. closing the connection is supposed to close all channels as well as the connection