### PR TITLE
Changing log4j config to log to persistent log location

### DIFF
--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -22,7 +22,7 @@
 
         <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
                 <!-- defines the name of the log file produced -->
-                <param name="file" value="target/test.log" />
+                <param name="file" value="logs/perkin.log" />
                 <param name="datePattern" value="'.'yyyy-MM" />
                 <param name="append" value="true" />
 


### PR DESCRIPTION
Changing log4j config to create a persistent log file.

To Test locally
Locally we can test that the file is being produced. Once merged into the amazon environment we can then see if the file is created in the correct place.
Locally do a mvn clean install and then navigate to the target directory and run:
java -jar Perkin-0.0.1-SNAPSHOT-jar-with-dependencies.jar

If the config has worked correctly you should see a perkin.log file appear in the target/logs.
Once merged, the amazon environment already has the volume setup and so we should be able to ssh to the machine and see the log file in home/ubuntu/edc/logs.