### PR TITLE
Added logs/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.jar
 *.DS_Store
 *.sequence
+logs/


### PR DESCRIPTION
## Changes

Added logs/ to .gitignore as this folder is getting created when building Perkin as a submodule in the Dockers project (https://github.com/ONSdigital/dockers).

## How to test

Need to get this merged in and updated into master to see if the Perkin submodule will no longer show as "dirty" after a build.

## Who can test

Anyone but @davidcarboni