### PR TITLE
Removed references to Posie in favour of sdx-decrypt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # perkin
 Perkin is a Questionnaire data transformer written in Java. It is a component of the Office of National Statistics (ONS) Survey Data Exchange (SDE) project which listens to a JMS queue for survey data.
-On receipt it hands off to Posie to decrypt the survey data, then transforms it into downstream formats and sends the data via ftp for processing by the ONS.
+On receipt it hands off to sdx-decrypt to decrypt the survey data, then transforms it into downstream formats and sends the data via ftp for processing by the ONS.
 
 ## Installation
 

--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -19,7 +19,7 @@ RABBITMQ_DEFAULT_USER=
 RABBITMQ_DEFAULT_PASS=
 
 # Decryption service
-DECRYPT_HOST=http://posie:5000/
+DECRYPT_HOST=http://sdx-decrypt:5000/
 DECRYPT_PATH=/decrypt
 
 # Survey receipt target


### PR DESCRIPTION
## Changes

Checked through the Perkin codebase for references to Posie.
These now point to sdx-decrypt instead.

## How to test

Ensure everything runs correctly in the docker-compose setup.

## Who can test

Anyone but @davidcarboni
